### PR TITLE
Fix issue with using random selection

### DIFF
--- a/news/36.bugfix
+++ b/news/36.bugfix
@@ -1,0 +1,1 @@
+Fix TypeError with "Select random items" option. @alecpm

--- a/plone/portlet/collection/collection.py
+++ b/plone/portlet/collection/collection.py
@@ -272,9 +272,11 @@ class Renderer(base.Renderer):
             limit = self.data.limit and min(len(results), self.data.limit) or 1
 
             if exclude_context:
-                results = [
+                results = tuple(
                     brain for brain in results if brain.getPath() != context_path
-                ]
+                )
+            else:
+                results = tuple(results)
             if len(results) < limit:
                 limit = len(results)
             results = random.sample(results, limit)


### PR DESCRIPTION
Trying to use the `random` without `exclude_context` selected results in the following error:

```
Traceback (most recent call last):
  File "/usr/local/plone-5.2/zeoserver/eggs/plone.portlets-2.3.2-py3.8.egg/plone/portlets/manager.py", line 119, in _lazyLoadPortlets
    isAvailable = renderer.available
  File "/usr/local/plone-5.2/zeoserver/eggs/plone.portlet.collection-3.3.6-py3.8.egg/plone/portlet/collection/collection.py", line 193, in available
    return len(self.results())
  File "/usr/local/plone-5.2/zeoserver/eggs/plone.memoize-3.0.0-py3.8.egg/plone/memoize/instance.py", line 53, in memogetter
    val = func(*args, **kwargs)
  File "/usr/local/plone-5.2/zeoserver/eggs/plone.portlet.collection-3.3.6-py3.8.egg/plone/portlet/collection/collection.py", line 212, in results
    return self._random_results()
  File "/usr/local/plone-5.2/zeoserver/eggs/plone.portlet.collection-3.3.6-py3.8.egg/plone/portlet/collection/collection.py", line 258, in _random_results
    results = random.sample(results, limit)
  File "/usr/lib/python3.8/random.py", line 359, in sample
    raise TypeError("Population must be a sequence or set.  For dicts, use list(d).")
TypeError: Population must be a sequence or set.  For dicts, use list(d).
```

The lazy map of brains needs to be converted into a sequence for `random.sample` to work. This could be much made more efficient by getting a random sample of indexes and only waking the brains at the selected indices. However, making that optimization for the `exclude_context` case is more complex. This PR implements a very simple fix that should be as efficient as the original code when it worked under previous Zope/Python versions.

I've also implemented this patch on a branch based on the `3.3.x` branch for Plone 5.2: `random-py3-fix-3.3.x`